### PR TITLE
Reserve a bit for RVE ABI in e_flags

### DIFF
--- a/riscv-elf.md
+++ b/riscv-elf.md
@@ -19,9 +19,9 @@
 * e_flags: Describes the format of this ELF file.  These flags are used by the
   linker to disallow linking ELF files with incompatible ABIs together.
 
-   Bit 0 | Bit  1 - 2 | Bit 3 - 31
-  -------|------------|-----------
-   RVC   | Float ABI  |   UNUSED
+   Bit 0 | Bit  1 - 2 | Bit 3 | Bit 4 - 31
+  -------|------------|-------|------------
+   RVC   | Float ABI  |  RVE  | UNUSED
 
 
   * EF_RISCV_RVC (0x0001): This bit is set when the binary targets the C ABI,
@@ -40,6 +40,7 @@
     store "float" and "double" values in F registers, but would not store "long
     double" values in F registers.  If none of the float ABI flags are set, the
     object is taken to use the soft-float ABI.
+  * EF_RISCV_RVE (0x0008): This bit is set when the binary targets the E ABI.
 
 # Sections
 


### PR DESCRIPTION
I think it's time to reserve e_flags for RVE even we don't implement yet.