### PR TITLE
Provide a clearer FP calling convention example (fixes #22)

### DIFF
--- a/riscv-elf.md
+++ b/riscv-elf.md
@@ -134,8 +134,8 @@ floating-point register in the ABI.  The ISA might have wider
 floating-point registers than the ABI.
 
 For the purposes of this section, "struct" refers to a C struct with its
-hierarchy flattened, including any array fields.  That is, struct { struct
-{ float f[1]; } g[2]; int h; } and struct { float f; float g; int h; } are
+hierarchy flattened, including any array fields.  That is, struct `{ struct
+{ float f[1]; } g[2]; }` and `struct { float f; float g; }` are
 treated the same.  Empty structs are ignored, even in C++, unless they
 have nontrivial copy constructors or destructors.
 


### PR DESCRIPTION
As discussed, the example struct introduced in the floating point calling
convention example will be passed as in the integer calling convention, which
isn't ideal. This PR removes a field so it is covered by the rule for a struct
containing two fp reals.