### PR TITLE
Describe callee-saved scheme

### DIFF
--- a/riscv-elf.md
+++ b/riscv-elf.md
@@ -146,6 +146,9 @@ The stack pointer shall be aligned to a 128-bit boundary upon procedure
 entry, except for the RV32E ABI, where it need only be aligned to 32 bits.
 The stack pointer need not remain aligned throughout procedure execution.
 
+Registers s0-s11 shall be preserved across procedure calls.
+No floating-point registers, if present, are preserved across calls.
+
 ## Hardware floating-point calling convention
 
 The hardware floating-point calling convention adds eight floating-point
@@ -192,6 +195,9 @@ Otherwise, it is passed according to the integer calling convention.
 
 Values are returned in the same manner as a first named argument of the same
 type would be passed.
+
+Floating-point registers fs0-fs11 shall be preserved across procedure calls,
+provided they hold values no more than FLEN bits wide.
 
 # Default ABIs and C type sizes
 


### PR DESCRIPTION
If you can think of a clearer way to explain the floating-point scheme, let me know...