### PR TITLE
Clarify that the int in an int+fp struct is sign-extended

### DIFF
--- a/riscv-elf.md
+++ b/riscv-elf.md
@@ -185,6 +185,7 @@ floating-point reals.
 
 A struct containing one floating-point real and one integer, in either
 order, is passed in a floating-point register and an integer register,
+with the integer zero- or sign-extended as though it were a scalar,
 provided the floating-point real is no more than FLEN bits wide and the
 integer is no more than XLEN bits wide, and at least one floating-point
 argument register and at least one integer argument register is available.


### PR DESCRIPTION
Closes #37