### PR TITLE
Document that the stack grows downwards

### DIFF
--- a/riscv-elf.md
+++ b/riscv-elf.md
@@ -142,11 +142,11 @@ type would be passed.  If such an argument would have been passed by
 reference, the caller allocates memory for the return value, and passes the
 address as an implicit first parameter.
 
-The stack pointer shall be aligned to a 128-bit boundary upon procedure
-entry, except for the RV32E ABI, where it need only be aligned to 32 bits.
-The stack pointer need not remain aligned throughout procedure execution.
-Procedures must not rely upon the persistence of stack-allocated data whose
-addresses lie below the stack pointer.
+The stack grows downwards and the stack pointer shall be aligned to a 128-bit
+boundary upon procedure entry, except for the RV32E ABI, where it need only be
+aligned to 32 bits.  The stack pointer need not remain aligned throughout
+procedure execution.  Procedures must not rely upon the persistence of
+stack-allocated data whose addresses lie below the stack pointer.
 
 Registers s0-s11 shall be preserved across procedure calls.
 No floating-point registers, if present, are preserved across calls.


### PR DESCRIPTION
This wasn't previously specified anywhere.

The diff is made larger than strictly necessary due to the 80 character re-wrap, which seems to be the convention for this file.