### PR TITLE
Document __int128 alignment on RV64

### DIFF
--- a/riscv-elf.md
+++ b/riscv-elf.md
@@ -225,6 +225,7 @@ default ABIs:
     int         |  4            |  4
     long        |  8            |  8
     long long   |  8            |  8
+    __int128    | 16            | 16
     void *      |  8            |  8
     float       |  4            |  4
     double      |  8            |  8


### PR DESCRIPTION
This documents the current behaviour of GCC. Although not part of the C
standard, the __int128/__uint128 types are mentioned in both the AArch64
and x86-64 ABI docs.