### PR TITLE
In the integer calling convention, reals are passed without sign extension

### DIFF
--- a/riscv-elf.md
+++ b/riscv-elf.md
@@ -125,7 +125,7 @@ undefined.
 
 Arguments passed by reference may be modified by the callee.
 
-Floating-point reals are passed the same way as integers of the same size, and
+Floating-point reals are passed the same way as aggregates of the same size,
 complex floating-point numbers are passed the same way as a struct containing
 two floating-point reals.
 


### PR DESCRIPTION
The previous wording indicated 32-bit floats should be sign-extended
when passed in wider integer registers (e.g. when using the lp64 ABI):

1) When passed in registers, scalars narrower than XLEN bits are widened
according to the sign of their type up to 32 bits, then sign-extended to
XLEN bits.
2) Floating-point reals are passed the same way as integers of the same
size
3) For aggregates, bits unused due to padding, and bits past the end of
an aggregate whose size in bits is not divisible by XLEN, are undefined.

This isn't obeyed in GCC (see
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=87690), and it seems likely
that the original wording simply intended to describe the behaviour
regarding selecting registers or passing on the stack, rather than
implying sign-extension.

Reword to say that reals are passed in the same way as aggregates of
the same size, which means when the float is narrower than XLEN the
extra bits are undefined.