### PR TITLE
Add a reference to the assembler manual

### DIFF
--- a/riscv-elf.md
+++ b/riscv-elf.md
@@ -436,6 +436,10 @@ Enum | ELF Reloc Type       | Description                     | Details
 Nonstandard extensions are free to use relocation numbers 192-255 for any
 purpose.  These relocations may conflict with other nonstandard extensions.
 
+This section and later ones contain fragments written in assembler. The precise
+assembler syntax, including that of the relocations, is described in the
+[RISC-V Assembly Programmer's Manual](https://github.com/riscv/riscv-asm-manual).
+
 ### Assembler Relocation Functions
 
 The following table lists assembler functions for emitting relocatable symbol references:


### PR DESCRIPTION
PR https://github.com/riscv/riscv-elf-psabi-doc/pull/83 will remove the obsolete table containing the assembler syntax of the relocation functions.

It seems a good idea to explicitly state that their syntax is specified in the assembler manual.

**Note**: I'm aware this might conflict with https://github.com/riscv/riscv-elf-psabi-doc/pull/83 so I'll wait until that PR is merged