### PR TITLE
Document value of _Alignof(max_align_t) on RV32G and RV64G

### DIFF
--- a/riscv-elf.md
+++ b/riscv-elf.md
@@ -300,7 +300,7 @@ the imaginary part.
 A future version of this specification may define an ILP32 ABI for
 RV64G, but currently this is not a supported operating mode.
 
-The value of `_Alignof(max_align_t)` is 16 for both RV32G and RV64G.
+The value of `_Alignof(max_align_t)` is 16.
 
 ## <a name=va-list-va-start-and-va-arg></a> va_list, va_start, and va_arg
 

--- a/riscv-elf.md
+++ b/riscv-elf.md
@@ -300,6 +300,8 @@ the imaginary part.
 A future version of this specification may define an ILP32 ABI for
 RV64G, but currently this is not a supported operating mode.
 
+The value of `_Alignof(max_align_t)` is 16 for both RV32G and RV64G.
+
 ## <a name=va-list-va-start-and-va-arg></a> va_list, va_start, and va_arg
 
 The `va_list` type is `void*`. A callee with variadic arguments is responsible


### PR DESCRIPTION
Closes #104.