### PR TITLE
Document that a null pointer for all types has the value zero

### DIFF
--- a/riscv-elf.md
+++ b/riscv-elf.md
@@ -300,6 +300,8 @@ the imaginary part.
 A future version of this specification may define an ILP32 ABI for
 RV64G, but currently this is not a supported operating mode.
 
+A null pointer (for all types) has the value zero.
+
 ## <a name=va-list-va-start-and-va-arg></a> va_list, va_start, and va_arg
 
 The `va_list` type is `void*`. A callee with variadic arguments is responsible


### PR DESCRIPTION
This is the same wording that the [x86-64 psABI](https://github.com/hjl-tools/x86-psABI/wiki/x86-64-psABI-1.0.pdf) uses. Since the value of a nullptr is not specified in the C standard (*), and the value of a nullptr is not specified in this ABI, the value is left for other parts of the implementation to specify (e.g., the compiler). Two conforming compilers could implement this differently, e.g., using 0x0 or 0xffffffff as null pointer value representations, and while both would be conforming, their programs would be ABI incompatible (**).

This fixes that by specifying that all implementations need to use 0 as the null pointer value for all types.

AFAICT, this is what all major compilers do anyways.

---

(*) C only requires that testing a pointer against the null-pointer **constant** 0 returns true if and only if the pointer is a null pointer. That is:  

```c
int c = 0; // not a constant
int* p = NULL; // null pointer
assert(p == (void*)0); // OK: p is a null pointer and 0 is a null pointer constant
assert(p == NULL); // OK, p is a null pointer and NULL is defined as (void*)0
assert(p == (void*)c); // IMPLEMENTATION-DEFINED
```

the last check is implementation-defined, because since `c` is not a null-pointer constant, the address of the pointers is actually compared, and if the address of the null pointer isn't 0, then the assert fails. 

See [C11 6.3.2.3p3-p4](https://port70.net/~nsz/c/c11/n1570.html#6.3.2.3p3), and in particular, [7.22.3.2p2 and its 261 footnote](https://port70.net/~nsz/c/c11/n1570.html#7.22.3.2p2) which calls this out: 

> [all bits zero] need not be the same as the representation of floating-point zero or a null pointer constant.

---

(**) Worst case, `malloc` is compiled with one compiler, returning NULL, while the caller is compiled with the other, where NULL has a different representation, and end up dereferencing (reading or writing) from an allocation that does not exist.