### PR TITLE
Add pc-relative relocation for FDE initial location.

### DIFF
--- a/riscv-elf.md
+++ b/riscv-elf.md
@@ -444,7 +444,8 @@ Enum | ELF Reloc Type       | Description                     | Details
 54   | R_RISCV_SET8         | Local label subtraction         |
 55   | R_RISCV_SET16        | Local label subtraction         |
 56   | R_RISCV_SET32        | Local label subtraction         |
-57-191  | *Reserved*        | Reserved for future standard use |
+57   | R_RISCV_32_PCREL     | PC-relative reference           | word32 = S + A - PC
+58-191  | *Reserved*        | Reserved for future standard use |
 192-255 | *Reserved*        | Reserved for nonstandard ABI extensions |
 
 Nonstandard extensions are free to use relocation numbers 192-255 for any


### PR DESCRIPTION
According to this commit:
https://github.com/riscv/riscv-binutils-gdb/commit/a6cbf936e3dce68114d28cdf60d510a3f78a6d40

Also, I notice that asb had already support the relocation in LLVM
https://reviews.llvm.org/D64715

Therefore, we should add it to the psabi spec :) 