### PR TITLE
Corrects spelling of CHAR_BIT

### DIFF
--- a/riscv-elf.md
+++ b/riscv-elf.md
@@ -349,7 +349,7 @@ There are two conventions for C type sizes and alignments.
 
 The alignment of `max_align_t` is 16.
 
-`CHAR_BITS` is 8.
+`CHAR_BIT` is 8.
 
 Structs and unions are aligned to the alignment of their most strictly aligned
 member. The size of any object is a multiple of its alignment.


### PR DESCRIPTION
I spelled this incorrectly in my previous PR. The C spec uses the singular spelling "CHAR_BIT", not the plural spelling.