### PR TITLE
Add DWARF register number information for CSRs

### DIFF
--- a/riscv-elf.md
+++ b/riscv-elf.md
@@ -868,10 +868,17 @@ Dwarf Number  | Register Name | Description
 0-31          | x0-x31        | Integer Registers
 32-63         | f0-f31        | Floating-point Registers
 64            |               | Alternate Frame Return Column
+65 - 3071     |               | Reserved for future standard extensions
+3072 - 4095   |               | Reserved for custom extensions
+4096 - 8191   |               | CSRs
 
 The alternate frame return column is meant to be used when unwinding from
 signal handlers, and stores the address where the signal handler will return
 to.
+
+There space for 4096 CSRs.  Each CSR is assigned a DWARF register
+number corresponding to its CSR number given in **Volume II: Privileged
+Architecture** of **The RISC-V Instruction Set Manual** plus 4096.
 
 # <a name=linux-abi></a> Linux-specific ABI
 


### PR DESCRIPTION
There are situations where it might be necessary to reference some
CSRs from the DWARF information.  For example, when unwinding from an
exception handler it could be necessary to reference 'mepc' as the
return address from the exception handler.

Rather than just add DWARF registers numbers for specific CSRs one at
a time as we need them, I'd like to propose that we allocate numbers
for all CSRs in one go.

When thinking how to number the CSRs I see a couple of possible
solutions, first we could allocate 4096 (the maximum number of CSRs)
DWARF register numbers and assign these to CSRs based on the CSR's
number within the specification (Volume II: Privileged Architecture).
The benefit is that the number for a CSR shouldn't need to change in
the future (I think), and adding new CSRs is easy.  The draw back is
that this means allocating a large number of DWARF register numbers,
many of which are currently not used.

A second possibility was to allocate DWARF register numbers
sequentially for the CSRs in the order they currently appear in the
spec.  This would require far fewer DWARF register numbers to be
allocated (maybe just ~250) but if we add more CSRs to the spec later
then these would need to be added to the end of the DWARF register
number list, and things would get very confused.  To try and avoid
this confusion we would probably have to list all of the CSRs in this
document.

One last detail that I wasn't sure about is if we should reserve some
register numbers, say 65 -> 100 for future as special purpose
registers, much as 64 is currently used as the alternative frame
return column.  Maybe we wouldn't need to set aside that many, but it
might be useful if any future special purpose registers didn't have to
be placed at 4160+.

In this patch I am suggesting that we take the first approach.