### PR TITLE
 Add R_RISCV_SET_ULEB128 and R_RISCV_SUB_ULEB128.

### DIFF
--- a/riscv-elf.md
+++ b/riscv-elf.md
@@ -504,7 +504,9 @@ Enum | ELF Reloc Type       | Description                     | Details
 55   | R_RISCV_SET16        | Local label subtraction         |
 56   | R_RISCV_SET32        | Local label subtraction         |
 57   | R_RISCV_32_PCREL     | PC-relative reference           | word32 = S + A - PC
-58-191  | *Reserved*        | Reserved for future standard use |
+58   | R_RISCV_SET_ULEB128  | Local label subtraction         | uleb128 = S + A
+59   | R_RISCV_SUB_ULEB128  | Local label subtraction         | uleb128 = old - S - A
+60-191  | *Reserved*        | Reserved for future standard use |
 192-255 | *Reserved*        | Reserved for nonstandard ABI extensions |
 
 Nonstandard extensions are free to use relocation numbers 192-255 for any


### PR DESCRIPTION
In order to implement uleb128 subtraction, we need two relocations for the
linker to re-calculate the value after relaxing.
Please reference the commit: https://sourceware.org/ml/binutils/2019-11/msg00393.html