### PR TITLE
Disallow combining ILP32E ABI with D ISA extension

### DIFF
--- a/riscv-elf.md
+++ b/riscv-elf.md
@@ -249,6 +249,10 @@ s0-s1, and only three temporaries, t0-t2.
 If used with an ISA that has any of the registers x16-x31 and f0-f31, then
 these registers are considered temporaries.
 
+The ILP32E calling convention is not compatible with ISAs that have registers
+that require load and store alignments of more than 32-bits. In particular, this
+calling convention must not be used with the D ISA extension.
+
 ## <a name=named-abis></a> Named ABIs
 
 This specification defines the following named ABIs:


### PR DESCRIPTION
As discussed in #125, this denies ILP32E with the D extension. In fact,
it goes slightly further to deny any extensions where the required load
and store alignment is larger than the stack alignment, because that is
the issue at play in #125. This wording should future-proof the psABI
against issues with other extensions as they become ratified.

---

Closes #125.

