### PR TITLE
Add definition for EF_RISCV_FLOAT_ABI_SOFT

### DIFF
--- a/riscv-elf.md
+++ b/riscv-elf.md
@@ -422,6 +422,7 @@ rules about 2✕XLEN aligned arguments being passed in "aligned" register pairs.
     and RV64 ISAs only allow 32-bit instruction alignment).  When linking
     objects which specify EF_RISCV_RVC, the linker is permitted to use RVC
     instructions such as C.JAL in the relaxation process.
+  * EF_RISCV_FLOAT_ABI_SOFT (0x0000)
   * EF_RISCV_FLOAT_ABI_SINGLE (0x0002)
   * EF_RISCV_FLOAT_ABI_DOUBLE (0x0004)
   * EF_RISCV_FLOAT_ABI_QUAD (0x0006): These three flags identify the floating

--- a/riscv-elf.md
+++ b/riscv-elf.md
@@ -425,12 +425,12 @@ rules about 2✕XLEN aligned arguments being passed in "aligned" register pairs.
   * EF_RISCV_FLOAT_ABI_SOFT (0x0000)
   * EF_RISCV_FLOAT_ABI_SINGLE (0x0002)
   * EF_RISCV_FLOAT_ABI_DOUBLE (0x0004)
-  * EF_RISCV_FLOAT_ABI_QUAD (0x0006): These three flags identify the floating
-    point ABI in use for this ELF file.  They store the largest floating-point
-    type that ends up in registers as part of the ABI (but do not control if
-    code generation is allowed to use floating-point internally).  The rule is
-    that if you have a floating-point type in a register, then you also have
-    all smaller floating-point types in registers.  For example _DOUBLE would
+  * EF_RISCV_FLOAT_ABI_QUAD (0x0006): These flags identify the floating point
+    ABI in use for this ELF file.  They store the largest floating-point type
+    that ends up in registers as part of the ABI (but do not control if code
+    generation is allowed to use floating-point internally).  The rule is that
+    if you have a floating-point type in a register, then you also have all
+    smaller floating-point types in registers.  For example _DOUBLE would
     store "float" and "double" values in F registers, but would not store "long
     double" values in F registers.  If none of the float ABI flags are set, the
     object is taken to use the soft-float ABI.


### PR DESCRIPTION
The value of `EF_RISCV_FLOAT_ABI_SOFT` should be zero in the bits reserved for the FP ABI in `e_flags` of the ELF header.