### PR TITLE
Draft for adding IEEE half-precision floating-point type.

### DIFF
--- a/riscv-elf.md
+++ b/riscv-elf.md
@@ -378,6 +378,7 @@ There are two conventions for C type sizes and alignments.
     long long            |  8            |  8
     __int128             | 16            | 16
     void *               |  8            |  8
+    _Float16             |  2            |  2
     float                |  4            |  4
     double               |  8            |  8
     long double          | 16            | 16
@@ -397,6 +398,7 @@ There are two conventions for C type sizes and alignments.
     long                 |  4            |  4
     long long            |  8            |  8
     void *               |  4            |  4
+    _Float16             |  2            |  2
     float                |  4            |  4
     double               |  8            |  8
     long double          | 16            | 16
@@ -419,6 +421,8 @@ Booleans (`bool`/`_Bool`) stored in memory or when being passed as scalar
 arguments are either `0` (`false`) or `1` (`true`).
 
 A null pointer (for all types) has the value zero.
+
+`_Float16` is as defined in the C ISO/IEC TS 18661-3 extension.
 
 `_Complex` types have the same layout as a struct containing two fields of the
 corresponding real type (`float`, `double`, or `long double`), with the first


### PR DESCRIPTION
In order to provide the broadest level of compatibility across language versions
and compilers in libraries and programs, we adopt the `__fp16` rather than `_Float16`
as half-precision floating-point types. For example in the `printf` case, there is
no format specifier for the C language extension type half-precision floating-point.
In the case of passing a `_Float16` to `%f` or `%d` the value will be ignored and
silently fail, and no value will be formatted. In the case of `__fp16`, there is an
implicit cast to double, therefore the value will be formatted. So if you pass
`_Float16` to printf, you won't be able to print it, as there is no printf format code
for half-precision floating-point types. If you pass __fp16 to printf, it will print
fine, as it will promote to double.

For implementation it in LLVM, 
In RISCV, set Opts.NativeHalfArgsAndReturns = 1;
When `zfh` extension is enabled, set Opts.NativeHalfType = 1;

ref:
1. https://clang.llvm.org/docs/LanguageExtensions.html#half-precision-floating-point
2. ARM C Language Extensions [http://infocenter.arm.com/help/topic/com.arm.doc.ihi0053d/IHI0053D_acle_2_1.pdf](ACLE)