### PR TITLE
Remove stub compact code model section

### DIFF
--- a/riscv-elf.md
+++ b/riscv-elf.md
@@ -365,16 +365,6 @@ a signed 32-bit offset, relative to the value of the `pc` register,
 can be produced.
 This code model is position independent.
 
-### Compact
-
-The compact code model allows the code to address the whole 64-bit address space,
-especially when code and data are located far apart.  By using the Global
-Offset Table, or GOT, to hold the 64-bit address literals, any memory position
-can be referred.  By using the instructions `lui` and `addi`, a signed 32-bit
-offset, relative to the value of the `gp` register, can be produced, referring
-to address literals in the GOT.  This code model is position independent.
-Does not apply to the ILP32 ABIs.
-
 # <a name=c-types></a>C type details
 
 ## <a name=c-type-sizes></a>C type sizes and alignments


### PR DESCRIPTION
This section is currently a draft, so should not feature in any official publication (and does not currently meet the requirements in the pull request policy so would never have been added were those in place at the time). Thus, until a concrete specification for it exists and is deemed to be a worthwhile addition, we should not talk about it and risk causing confusion. Especially since, as currently described, it's a new ABI, not just a new code model, due to the requirement that gp always be able to be used to access the GOT, which isn't necessarily the case currently for executables, and is never the case currently for shared libraries as far as linkers are concerned.
